### PR TITLE
fix: refactor logging API to use type-safe Field pattern

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,13 @@ tasks:
     cmds:
       - task --list
 
+  vendor:
+    desc: Run go mod vendor
+    silent: true
+    cmds:
+      - go mod tidy
+      - go mod vendor
+
   test:
     desc: Run unit tests with coverage
     silent: true

--- a/argo/client.go
+++ b/argo/client.go
@@ -40,9 +40,9 @@ func NewClient(ctx context.Context, config *Config) (context.Context, apiclient.
 	logger := otel.NewLogHelper(ctx, config.OTelConfig, "github.com/jasoet/pkg/v2/argo", "argo.NewClient")
 
 	logger.Debug("Creating Argo Workflows client",
-		"inCluster", config.InCluster,
-		"kubeConfigPath", config.KubeConfigPath,
-		"argoServerURL", config.ArgoServerOpts.URL,
+		otel.F("inCluster", config.InCluster),
+		otel.F("kubeConfigPath", config.KubeConfigPath),
+		otel.F("argoServerURL", config.ArgoServerOpts.URL),
 	)
 
 	// Build Argo client options
@@ -125,7 +125,7 @@ func buildClientConfig(config *Config) clientcmd.ClientConfig {
 
 	// Set explicit path if provided
 	if config.KubeConfigPath != "" {
-		logger.Debug("Using explicit kubeconfig path", "path", config.KubeConfigPath)
+		logger.Debug("Using explicit kubeconfig path", otel.F("path", config.KubeConfigPath))
 		loadingRules.ExplicitPath = config.KubeConfigPath
 	} else {
 		// Use default kubeconfig location
@@ -135,7 +135,7 @@ func buildClientConfig(config *Config) clientcmd.ClientConfig {
 	// Build config overrides
 	overrides := &clientcmd.ConfigOverrides{}
 	if config.Context != "" {
-		logger.Debug("Using explicit context", "context", config.Context)
+		logger.Debug("Using explicit context", otel.F("context", config.Context))
 		overrides.CurrentContext = config.Context
 	}
 
@@ -208,11 +208,11 @@ func GetRestConfig(inCluster bool) (*rest.Config, error) {
 	if !inCluster {
 		kubeConfig = filepath.Join(clientcmd.RecommendedConfigDir, clientcmd.RecommendedFileName)
 		logger.Debug("Using kubeconfig file",
-			"inCluster", inCluster,
-			"kubeConfigPath", kubeConfig,
+			otel.F("inCluster", inCluster),
+			otel.F("kubeConfigPath", kubeConfig),
 		)
 	} else {
-		logger.Debug("Using in-cluster config", "inCluster", inCluster)
+		logger.Debug("Using in-cluster config", otel.F("inCluster", inCluster))
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)

--- a/argo/config.go
+++ b/argo/config.go
@@ -65,8 +65,8 @@ func DefaultConfig() *Config {
 
 	logger := otel.NewLogHelper(context.Background(), config.OTelConfig, "github.com/jasoet/pkg/v2/argo", "argo.DefaultConfig")
 	logger.Debug("Created default Argo configuration",
-		"inCluster", config.InCluster,
-		"kubeConfigPath", config.KubeConfigPath,
+		otel.F("inCluster", config.InCluster),
+		otel.F("kubeConfigPath", config.KubeConfigPath),
 	)
 
 	return config
@@ -99,7 +99,7 @@ func ArgoServerConfig(serverURL string, authToken string) *Config {
 	}
 
 	logger := otel.NewLogHelper(context.Background(), config.OTelConfig, "github.com/jasoet/pkg/v2/argo", "argo.ArgoServerConfig")
-	logger.Debug("Created Argo Server configuration", "serverURL", serverURL)
+	logger.Debug("Created Argo Server configuration", otel.F("serverURL", serverURL))
 
 	return config
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/uber-go/tally/v4 v4.1.17
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.63.0
 	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.14.0
 	go.opentelemetry.io/otel/log v0.14.0
 	go.opentelemetry.io/otel/metric v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,6 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 h1:IeMey
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0/go.mod h1:oVdCUtjq9MK9BlS7TtucsQwUcXcymNiEDjgDD2jMtZU=
 go.opentelemetry.io/otel/exporters/prometheus v0.58.0 h1:CJAxWKFIqdBennqxJyOgnt5LqkeFRT+Mz3Yjz3hL+h8=
 go.opentelemetry.io/otel/exporters/prometheus v0.58.0/go.mod h1:7qo/4CLI+zYSNbv0GMNquzuss2FVZo3OYrGh96n4HNc=
-go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.14.0 h1:B/g+qde6Mkzxbry5ZZag0l7QrQBCtVm7lVjaLgmpje8=
-go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.14.0/go.mod h1:mOJK8eMmgW6ocDJn6Bn11CcZ05gi3P8GylBXEkZtbgA=
 go.opentelemetry.io/otel/log v0.14.0 h1:2rzJ+pOAZ8qmZ3DDHg73NEKzSZkhkGIua9gXtxNGgrM=
 go.opentelemetry.io/otel/log v0.14.0/go.mod h1:5jRG92fEAgx0SU/vFPxmJvhIuDU9E1SUnEQrMlJpOno=
 go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
@@ -646,8 +644,6 @@ go.opentelemetry.io/otel/sdk v1.38.0 h1:l48sr5YbNf2hpCUj/FoGhW9yDkl+Ma+LrVl8qaM5
 go.opentelemetry.io/otel/sdk v1.38.0/go.mod h1:ghmNdGlVemJI3+ZB5iDEuk4bWA3GkTpW+DOoZMYBVVg=
 go.opentelemetry.io/otel/sdk/log v0.14.0 h1:JU/U3O7N6fsAXj0+CXz21Czg532dW2V4gG1HE/e8Zrg=
 go.opentelemetry.io/otel/sdk/log v0.14.0/go.mod h1:imQvII+0ZylXfKU7/wtOND8Hn4OpT3YUoIgqJVksUkM=
-go.opentelemetry.io/otel/sdk/log/logtest v0.14.0 h1:Ijbtz+JKXl8T2MngiwqBlPaHqc4YCaP/i13Qrow6gAM=
-go.opentelemetry.io/otel/sdk/log/logtest v0.14.0/go.mod h1:dCU8aEL6q+L9cYTqcVOk8rM9Tp8WdnHOPLiBgp0SGOA=
 go.opentelemetry.io/otel/sdk/metric v1.38.0 h1:aSH66iL0aZqo//xXzQLYozmWrXxyFkBJ6qT5wthqPoM=
 go.opentelemetry.io/otel/sdk/metric v1.38.0/go.mod h1:dg9PBnW9XdQ1Hd6ZnRz689CbtrUp0wMMs9iPcgT9EZA=
 go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=

--- a/otel/config_test.go
+++ b/otel/config_test.go
@@ -482,7 +482,7 @@ func TestShutdown(t *testing.T) {
 
 func TestDefaultLoggerProvider(t *testing.T) {
 	t.Run("creates a logger provider", func(t *testing.T) {
-		lp := defaultLoggerProvider()
+		lp := defaultLoggerProvider("test-service", false)
 
 		if lp == nil {
 			t.Error("expected defaultLoggerProvider to return a provider")
@@ -490,7 +490,7 @@ func TestDefaultLoggerProvider(t *testing.T) {
 	})
 
 	t.Run("created logger can emit logs", func(t *testing.T) {
-		lp := defaultLoggerProvider()
+		lp := defaultLoggerProvider("test-service", false)
 		logger := lp.Logger("test-scope")
 
 		// Should not panic

--- a/otel/helper_test.go
+++ b/otel/helper_test.go
@@ -63,7 +63,7 @@ func TestLogHelper_Debug(t *testing.T) {
 		helper := NewLogHelper(ctx, nil, "", "test.Function")
 		// Should not panic
 		helper.Debug("debug message")
-		helper.Debug("debug message with fields", "key", "value", "count", 42)
+		helper.Debug("debug message with fields", F("key", "value"), F("count", 42))
 	})
 
 	t.Run("with OTel", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestLogHelper_Debug(t *testing.T) {
 		helper := NewLogHelper(ctx, cfg, "test-scope", "test.Function")
 		// Should not panic
 		helper.Debug("debug message")
-		helper.Debug("debug message with fields", "key", "value", "count", 42)
+		helper.Debug("debug message with fields", F("key", "value"), F("count", 42))
 	})
 }
 
@@ -85,7 +85,7 @@ func TestLogHelper_Info(t *testing.T) {
 		helper := NewLogHelper(ctx, nil, "", "test.Function")
 		// Should not panic
 		helper.Info("info message")
-		helper.Info("info message with fields", "key", "value", "enabled", true)
+		helper.Info("info message with fields", F("key", "value"), F("enabled", true))
 	})
 
 	t.Run("with OTel", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestLogHelper_Info(t *testing.T) {
 		helper := NewLogHelper(ctx, cfg, "test-scope", "test.Function")
 		// Should not panic
 		helper.Info("info message")
-		helper.Info("info message with fields", "key", "value", "enabled", true)
+		helper.Info("info message with fields", F("key", "value"), F("enabled", true))
 	})
 }
 
@@ -107,7 +107,7 @@ func TestLogHelper_Warn(t *testing.T) {
 		helper := NewLogHelper(ctx, nil, "", "test.Function")
 		// Should not panic
 		helper.Warn("warning message")
-		helper.Warn("warning message with fields", "key", "value", "ratio", 0.75)
+		helper.Warn("warning message with fields", F("key", "value"), F("ratio", 0.75))
 	})
 
 	t.Run("with OTel", func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestLogHelper_Warn(t *testing.T) {
 		helper := NewLogHelper(ctx, cfg, "test-scope", "test.Function")
 		// Should not panic
 		helper.Warn("warning message")
-		helper.Warn("warning message with fields", "key", "value", "ratio", 0.75)
+		helper.Warn("warning message with fields", F("key", "value"), F("ratio", 0.75))
 	})
 }
 
@@ -130,7 +130,7 @@ func TestLogHelper_Error(t *testing.T) {
 		helper := NewLogHelper(ctx, nil, "", "test.Function")
 		// Should not panic
 		helper.Error(testErr, "error message")
-		helper.Error(testErr, "error message with fields", "key", "value", "code", 500)
+		helper.Error(testErr, "error message with fields", F("key", "value"), F("code", 500))
 	})
 
 	t.Run("with OTel", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestLogHelper_Error(t *testing.T) {
 		helper := NewLogHelper(ctx, cfg, "test-scope", "test.Function")
 		// Should not panic
 		helper.Error(testErr, "error message")
-		helper.Error(testErr, "error message with fields", "key", "value", "code", 500)
+		helper.Error(testErr, "error message with fields", F("key", "value"), F("code", 500))
 	})
 }
 
@@ -151,11 +151,11 @@ func TestLogHelper_MixedTypes(t *testing.T) {
 	t.Run("various data types without OTel", func(t *testing.T) {
 		helper := NewLogHelper(ctx, nil, "", "test.Function")
 		helper.Info("mixed types",
-			"string", "value",
-			"int", 123,
-			"int64", int64(456),
-			"bool", true,
-			"float64", 3.14,
+			F("string", "value"),
+			F("int", 123),
+			F("int64", int64(456)),
+			F("bool", true),
+			F("float64", 3.14),
 		)
 	})
 
@@ -166,47 +166,12 @@ func TestLogHelper_MixedTypes(t *testing.T) {
 		}
 		helper := NewLogHelper(ctx, cfg, "test-scope", "test.Function")
 		helper.Info("mixed types",
-			"string", "value",
-			"int", 123,
-			"int64", int64(456),
-			"bool", true,
-			"float64", 3.14,
+			F("string", "value"),
+			F("int", 123),
+			F("int64", int64(456)),
+			F("bool", true),
+			F("float64", 3.14),
 		)
 	})
 }
 
-func TestLogHelper_InvalidKeyValuePairs(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("odd number of arguments without OTel", func(t *testing.T) {
-		helper := NewLogHelper(ctx, nil, "", "test.Function")
-		// Should not panic with odd number of arguments
-		helper.Info("message", "key")
-	})
-
-	t.Run("odd number of arguments with OTel", func(t *testing.T) {
-		cfg := &Config{
-			ServiceName:    "test-service",
-			LoggerProvider: noop.NewLoggerProvider(),
-		}
-		helper := NewLogHelper(ctx, cfg, "test-scope", "test.Function")
-		// Should not panic with odd number of arguments
-		helper.Info("message", "key")
-	})
-
-	t.Run("non-string keys without OTel", func(t *testing.T) {
-		helper := NewLogHelper(ctx, nil, "", "test.Function")
-		// Should not panic with non-string keys
-		helper.Info("message", 123, "value")
-	})
-
-	t.Run("non-string keys with OTel", func(t *testing.T) {
-		cfg := &Config{
-			ServiceName:    "test-service",
-			LoggerProvider: noop.NewLoggerProvider(),
-		}
-		helper := NewLogHelper(ctx, cfg, "test-scope", "test.Function")
-		// Should not panic with non-string keys
-		helper.Info("message", 123, "value")
-	})
-}

--- a/rest/client.go
+++ b/rest/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/jasoet/pkg/v2/otel"
-	"github.com/rs/zerolog/log"
 )
 
 type Client struct {
@@ -134,7 +133,11 @@ func (c *Client) GetMiddlewares() []Middleware {
 }
 
 func (c *Client) MakeRequestWithTrace(ctx context.Context, method string, url string, body string, headers map[string]string) (*resty.Response, error) {
-	_log := log.With().Ctx(ctx).Str("function", "MakeRequestWithTrace").Str("url", url).Logger()
+	var otelConfig *otel.Config
+	if c.restConfig != nil {
+		otelConfig = c.restConfig.OTelConfig
+	}
+	logger := otel.NewLogHelper(ctx, otelConfig, "github.com/jasoet/pkg/v2/rest", "rest.MakeRequestWithTrace")
 
 	if c.restClient == nil {
 		return nil, errors.New("rest client is nil")
@@ -208,7 +211,7 @@ func (c *Client) MakeRequestWithTrace(ctx context.Context, method string, url st
 	}
 
 	if err != nil {
-		_log.Error().Err(err).Msg("Failed to make request")
+		logger.Error(err, "Failed to make request")
 		return response, NewExecutionError("Failed to make request", err)
 	}
 
@@ -221,7 +224,11 @@ func (c *Client) MakeRequestWithTrace(ctx context.Context, method string, url st
 }
 
 func (c *Client) MakeRequest(ctx context.Context, method string, url string, body string, headers map[string]string) (*resty.Response, error) {
-	_log := log.With().Ctx(ctx).Str("function", "MakeRequest").Str("url", url).Logger()
+	var otelConfig *otel.Config
+	if c.restConfig != nil {
+		otelConfig = c.restConfig.OTelConfig
+	}
+	logger := otel.NewLogHelper(ctx, otelConfig, "github.com/jasoet/pkg/v2/rest", "rest.MakeRequest")
 
 	if c.restClient == nil {
 		return nil, errors.New("rest client is nil")
@@ -291,7 +298,7 @@ func (c *Client) MakeRequest(ctx context.Context, method string, url string, bod
 	}
 
 	if err != nil {
-		_log.Error().Err(err).Msg("Failed to make request")
+		logger.Error(err, "Failed to make request")
 		return response, NewExecutionError("Failed to make request", err)
 	}
 

--- a/rest/middleware.go
+++ b/rest/middleware.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/rs/zerolog/log"
+	"github.com/jasoet/pkg/v2/otel"
 )
 
 type RequestInfo struct {
@@ -48,17 +48,20 @@ func (m *LoggingMiddleware) BeforeRequest(ctx context.Context, method string, ur
 
 // AfterRequest logs the completion of the request with timing information
 func (m *LoggingMiddleware) AfterRequest(ctx context.Context, info RequestInfo) {
-	logger := log.With().Ctx(ctx).
-		Str("method", info.Method).
-		Str("url", info.URL).
-		Int("status_code", info.StatusCode).
-		Dur("duration", info.Duration).
-		Logger()
+	logger := otel.NewLogHelper(ctx, nil, "github.com/jasoet/pkg/v2/rest", "LoggingMiddleware.AfterRequest")
 
 	if info.Error != nil {
-		logger.Error().Err(info.Error).Msg("Request failed")
+		logger.Error(info.Error, "Request failed",
+			otel.F("method", info.Method),
+			otel.F("url", info.URL),
+			otel.F("status_code", info.StatusCode),
+			otel.F("duration", info.Duration))
 	} else {
-		logger.Info().Msg("Request completed")
+		logger.Info("Request completed",
+			otel.F("method", info.Method),
+			otel.F("url", info.URL),
+			otel.F("status_code", info.StatusCode),
+			otel.F("duration", info.Duration))
 	}
 }
 
@@ -97,17 +100,21 @@ func (m *DatabaseLoggingMiddleware) BeforeRequest(ctx context.Context, method st
 func (m *DatabaseLoggingMiddleware) AfterRequest(ctx context.Context, info RequestInfo) {
 	// TODO: Implement actual database logging
 	// For now, just log to console similar to LoggingMiddleware
-	logger := log.With().Ctx(ctx).
-		Str("middleware", "database").
-		Str("method", info.Method).
-		Str("url", info.URL).
-		Int("status_code", info.StatusCode).
-		Dur("duration", info.Duration).
-		Logger()
+	logger := otel.NewLogHelper(ctx, nil, "github.com/jasoet/pkg/v2/rest", "DatabaseLoggingMiddleware.AfterRequest")
 
 	if info.Error != nil {
-		logger.Error().Err(info.Error).Msg("Request failed (would log to database)")
+		logger.Error(info.Error, "Request failed (would log to database)",
+			otel.F("middleware", "database"),
+			otel.F("method", info.Method),
+			otel.F("url", info.URL),
+			otel.F("status_code", info.StatusCode),
+			otel.F("duration", info.Duration))
 	} else {
-		logger.Info().Msg("Request completed (would log to database)")
+		logger.Info("Request completed (would log to database)",
+			otel.F("middleware", "database"),
+			otel.F("method", info.Method),
+			otel.F("url", info.URL),
+			otel.F("status_code", info.StatusCode),
+			otel.F("duration", info.Duration))
 	}
 }

--- a/temporal/client.go
+++ b/temporal/client.go
@@ -1,10 +1,13 @@
 package temporal
 
 import (
+	"context"
+	"os"
 	"time"
 
+	"github.com/jasoet/pkg/v2/otel"
 	prom "github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	"github.com/uber-go/tally/v4"
 	"github.com/uber-go/tally/v4/prometheus"
 	"go.temporal.io/sdk/client"
@@ -12,17 +15,25 @@ import (
 )
 
 func NewClientWithMetrics(config *Config, metricsEnabled bool) (client.Client, error) {
-	logger := log.With().Str("function", "temporal.NewClient").Logger()
-	logger.Debug().
-		Str("hostPort", config.HostPort).
-		Str("namespace", config.Namespace).
-		Str("metricsAddress", config.MetricsListenAddress).
-		Msg("Creating new Temporal client")
+	ctx := context.Background()
+	logger := otel.NewLogHelper(ctx, nil, "github.com/jasoet/pkg/v2/temporal", "temporal.NewClientWithMetrics")
+
+	logger.Debug("Creating new Temporal client",
+		otel.F("hostPort", config.HostPort),
+		otel.F("namespace", config.Namespace),
+		otel.F("metricsAddress", config.MetricsListenAddress))
+
+	// Create a zerolog logger for Temporal SDK's logger adapter
+	zerologLogger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).
+		With().
+		Timestamp().
+		Str("service", "temporal").
+		Logger()
 
 	clientOption := client.Options{
 		HostPort:  config.HostPort,
 		Namespace: config.Namespace,
-		Logger:    NewZerologAdapter(logger),
+		Logger:    NewZerologAdapter(zerologLogger),
 	}
 
 	if !metricsEnabled {
@@ -31,21 +42,21 @@ func NewClientWithMetrics(config *Config, metricsEnabled bool) (client.Client, e
 			TimerType:     "histogram",
 		})
 		if err != nil {
-			logger.Error().Err(err).Msg("Failed to create Prometheus scope")
+			logger.Error(err, "Failed to create Prometheus scope")
 			return nil, err
 		}
 
 		clientOption.MetricsHandler = sdktally.NewMetricsHandler(scope)
 	}
 
-	logger.Debug().Msg("Connecting to Temporal server")
+	logger.Debug("Connecting to Temporal server")
 	c, err := client.Dial(clientOption)
 	if err != nil {
-		logger.Error().Err(err).Msg("Failed to connect to Temporal server")
+		logger.Error(err, "Failed to connect to Temporal server")
 		return nil, err
 	}
 
-	logger.Debug().Msg("Successfully connected to Temporal server")
+	logger.Debug("Successfully connected to Temporal server")
 	return c, nil
 }
 
@@ -54,33 +65,36 @@ func NewClient(config *Config) (client.Client, error) {
 }
 
 func newPrometheusScope(c prometheus.Configuration) (tally.Scope, error) {
-	logger := log.With().Str("function", "temporal.newPrometheusScope").Logger()
-	logger.Debug().Str("listenAddress", c.ListenAddress).Msg("Creating Prometheus reporter")
+	ctx := context.Background()
+	logger := otel.NewLogHelper(ctx, nil, "github.com/jasoet/pkg/v2/temporal", "temporal.newPrometheusScope")
+
+	logger.Debug("Creating Prometheus reporter", otel.F("listenAddress", c.ListenAddress))
 
 	reporter, err := c.NewReporter(
 		prometheus.ConfigurationOptions{
 			Registry: prom.NewRegistry(),
 			OnError: func(err error) {
-				log.Error().Err(err).Msg("Error in Prometheus reporter")
+				errLogger := otel.NewLogHelper(ctx, nil, "github.com/jasoet/pkg/v2/temporal", "temporal.prometheusReporter.OnError")
+				errLogger.Error(err, "Error in Prometheus reporter")
 			},
 		},
 	)
 	if err != nil {
-		logger.Error().Err(err).Msg("Failed to create Prometheus reporter")
+		logger.Error(err, "Failed to create Prometheus reporter")
 		return nil, err
 	}
 
-	logger.Debug().Msg("Configuring tally scope options")
+	logger.Debug("Configuring tally scope options")
 	scopeOpts := tally.ScopeOptions{
 		CachedReporter:  reporter,
 		Separator:       prometheus.DefaultSeparator,
 		SanitizeOptions: &sdktally.PrometheusSanitizeOptions,
 	}
 
-	logger.Debug().Msg("Creating new root scope")
+	logger.Debug("Creating new root scope")
 	scope, _ := tally.NewRootScope(scopeOpts, time.Second)
 	scope = sdktally.NewPrometheusNamingScope(scope)
 
-	logger.Debug().Msg("Prometheus scope created successfully")
+	logger.Debug("Prometheus scope created successfully")
 	return scope, nil
 }

--- a/temporal/config.go
+++ b/temporal/config.go
@@ -1,7 +1,9 @@
 package temporal
 
 import (
-	"github.com/rs/zerolog/log"
+	"context"
+
+	"github.com/jasoet/pkg/v2/otel"
 )
 
 type Config struct {
@@ -11,7 +13,8 @@ type Config struct {
 }
 
 func DefaultConfig() *Config {
-	logger := log.With().Str("function", "temporal.DefaultConfig").Logger()
+	ctx := context.Background()
+	logger := otel.NewLogHelper(ctx, nil, "github.com/jasoet/pkg/v2/temporal", "temporal.DefaultConfig")
 
 	config := &Config{
 		HostPort:             "localhost:7233",
@@ -19,11 +22,10 @@ func DefaultConfig() *Config {
 		MetricsListenAddress: "0.0.0.0:9090",
 	}
 
-	logger.Debug().
-		Str("hostPort", config.HostPort).
-		Str("namespace", config.Namespace).
-		Str("metricsAddress", config.MetricsListenAddress).
-		Msg("Created default Temporal configuration")
+	logger.Debug("Created default Temporal configuration",
+		otel.F("hostPort", config.HostPort),
+		otel.F("namespace", config.Namespace),
+		otel.F("metricsAddress", config.MetricsListenAddress))
 
 	return config
 }


### PR DESCRIPTION
## Summary
Refactors the LogHelper API from error-prone variadic `keysAndValues ...interface{}` to a type-safe Field-based pattern using the `F(key, value)` helper function.

## Changes
- ✅ Add Field struct and F() helper for type-safe field creation
- ✅ Update LogHelper methods (Debug/Info/Warn/Error) to accept `...Field`
- ✅ Replace all `interface{}` with `any` for modern Go idioms
- ✅ Update emitOTel() and addFields() to process Field slices
- ✅ Add support for time.Duration and fallback formatting via fmt.Sprint
- ✅ Update 78+ call sites across otel, argo, rest, temporal packages
- ✅ Remove invalid key-value pair tests (no longer applicable)

## Benefits
- Type-safe logging API prevents runtime errors
- Cleaner, more readable logging calls
- Follows modern Go patterns (similar to slog.Attr)
- Better IDE support and autocomplete
- Consistent API across all packages

## Testing
- ✅ All otel package tests pass
- ✅ All rest package tests pass
- ✅ All modified packages compile successfully
- ✅ Vendor dependencies updated

## Migration Example
**Before:**
```go
logger.Debug("Creating schedule", "scheduleID", scheduleID, "taskQueue", taskQueue)
```

**After:**
```go
logger.Debug("Creating schedule", 
    otel.F("scheduleID", scheduleID),
    otel.F("taskQueue", taskQueue))
```